### PR TITLE
Add permissions block to other workflow job

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/shenanigansd/programming-language/security/code-scanning/1](https://github.com/shenanigansd/programming-language/security/code-scanning/1)

To fix the problem, we need to add an explicit `permissions` block to the `build` job, limiting the GITHUB_TOKEN permissions to only what is required. In this scenario, only read access to repository contents is necessary, so we can safely set `permissions: contents: read`. The change should be applied under the `build:` job header (after line 10, before `runs-on:`) in `.github/workflows/docs.yaml`. No new methods, imports, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
