### PR TITLE
Track source positions in expressions for better error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,3 +43,6 @@ dependencies = [
 [[package]]
 name = "amarok-syntax"
 version = "0.1.0"
+dependencies = [
+ "amarok-diagnostics",
+]

--- a/crates/amarok-cli/src/lib.rs
+++ b/crates/amarok-cli/src/lib.rs
@@ -29,7 +29,7 @@ pub fn run_source(source: &str) -> String {
             Ok(Some(value)) => output.push(value.to_string()),
             Ok(None) => {}
             Err(diagnostic) => {
-                output.push(format!("runtime error: {}", diagnostic.message));
+                output.push(render(source, &diagnostic));
                 break; // stop at the first runtime error
             }
         }

--- a/crates/amarok-cli/tests/run_source.rs
+++ b/crates/amarok-cli/tests/run_source.rs
@@ -21,16 +21,36 @@ fn a_let_declaration_alone_produces_no_output() {
 }
 
 #[test]
-fn an_undefined_variable_is_a_runtime_error() {
-    assert!(run_source("y;").contains("runtime error"));
+fn an_undefined_variable_renders_a_caret() {
+    let output = run_source("missing;");
+    assert!(output.contains('^'));
+    assert!(output.contains("undefined variable"));
+}
+
+#[test]
+fn a_type_mismatch_renders_a_caret_at_the_operator() {
+    // 1 + "a"  — the '+' sits at column 2, so the caret should land there, the
+    // same visual format as a lex or parse error.
+    let output = run_source("1 + \"a\";");
+    let caret_line = output
+        .lines()
+        .nth(1)
+        .expect("a caret line below the source");
+    assert_eq!(caret_line.find('^'), Some(2));
+}
+
+#[test]
+fn division_by_zero_renders_a_caret() {
+    let output = run_source("5 / 0;");
+    assert!(output.contains('^'));
 }
 
 #[test]
 fn a_parse_error_renders_a_caret() {
-    assert!(run_source("let x = 5").contains("^")); // missing semicolon
+    assert!(run_source("let x = 5").contains('^')); // missing semicolon
 }
 
 #[test]
 fn a_lex_error_renders_a_caret() {
-    assert!(run_source("@;").contains("^"));
+    assert!(run_source("@;").contains('^'));
 }

--- a/crates/amarok-interpreter/src/lib.rs
+++ b/crates/amarok-interpreter/src/lib.rs
@@ -1,6 +1,6 @@
 pub use amarok_diagnostics::Diagnostic;
 use amarok_diagnostics::SourcePosition;
-use amarok_syntax::{BinaryOperator, Expression, Statement, UnaryOperator};
+use amarok_syntax::{BinaryOperator, Expression, ExpressionKind, Statement, UnaryOperator};
 use std::collections::HashMap;
 use std::fmt;
 
@@ -55,38 +55,45 @@ impl Environment {
 /// Returns a diagnostic when evaluation encounters invalid operand types or
 /// illegal operations such as division by zero.
 pub fn evaluate(expression: &Expression, environment: &Environment) -> Result<Value, Diagnostic> {
-    match expression {
-        Expression::NumberLiteral(number) => Ok(Value::Number(*number)),
-        Expression::StringLiteral(text) => Ok(Value::String(text.clone())),
-        Expression::BooleanLiteral(boolean) => Ok(Value::Boolean(*boolean)),
-        Expression::NilLiteral => Ok(Value::Nil),
-        Expression::Variable(name) => match environment.get(name) {
+    match &expression.kind {
+        ExpressionKind::NumberLiteral(number) => Ok(Value::Number(*number)),
+        ExpressionKind::StringLiteral(text) => Ok(Value::String(text.clone())),
+        ExpressionKind::BooleanLiteral(boolean) => Ok(Value::Boolean(*boolean)),
+        ExpressionKind::NilLiteral => Ok(Value::Nil),
+        ExpressionKind::Variable(name) => match environment.get(name) {
             Some(value) => Ok(value.clone()),
-            None => Err(runtime_error(format!("undefined variable '{name}'"))),
+            None => Err(runtime_error(
+                format!("undefined variable '{name}'"),
+                expression.position,
+            )),
         },
-        Expression::Unary { operator, operand } => {
+        ExpressionKind::Unary { operator, operand } => {
             let operand_value = evaluate(operand, environment)?;
-            evaluate_unary(*operator, operand_value)
+            evaluate_unary(*operator, operand_value, expression.position)
         }
-        Expression::Binary {
+        ExpressionKind::Binary {
             left,
             operator,
             right,
         } => {
             let left_value = evaluate(left, environment)?;
             let right_value = evaluate(right, environment)?;
-            evaluate_binary(*operator, left_value, right_value)
+            evaluate_binary(left_value, *operator, right_value, expression.position)
         }
     }
 }
 
-fn evaluate_unary(operator: UnaryOperator, operand: Value) -> Result<Value, Diagnostic> {
+fn evaluate_unary(
+    operator: UnaryOperator,
+    operand: Value,
+    position: SourcePosition,
+) -> Result<Value, Diagnostic> {
     match operator {
         UnaryOperator::Negate => match operand {
             Value::Number(number) => Ok(Value::Number(-number)),
-            other => Err(Diagnostic::new(
+            other => Err(runtime_error(
                 format!("cannot negate a {} value", type_name(&other)),
-                SourcePosition { character_index: 0 },
+                position,
             )),
         },
         UnaryOperator::Not => Ok(Value::Boolean(!is_truthy(&operand))),
@@ -94,35 +101,44 @@ fn evaluate_unary(operator: UnaryOperator, operand: Value) -> Result<Value, Diag
 }
 
 fn evaluate_binary(
-    operator: BinaryOperator,
     left: Value,
+    operator: BinaryOperator,
     right: Value,
+    position: SourcePosition,
 ) -> Result<Value, Diagnostic> {
     match operator {
         BinaryOperator::Add => match (left, right) {
             (Value::Number(a), Value::Number(b)) => Ok(Value::Number(a + b)),
             (Value::String(a), Value::String(b)) => Ok(Value::String(a + &b)),
-            (left, right) => Err(runtime_error(format!(
-                "cannot add a {} and a {}",
-                type_name(&left),
-                type_name(&right),
-            ))),
+            (left, right) => Err(runtime_error(
+                format!(
+                    "cannot add a {} and a {}",
+                    type_name(&left),
+                    type_name(&right),
+                ),
+                position,
+            )),
         },
-        BinaryOperator::Subtract => arithmetic(left, right, "subtract", |a, b| a - b),
-        BinaryOperator::Multiply => arithmetic(left, right, "multiply", |a, b| a * b),
+        BinaryOperator::Subtract => arithmetic(left, right, "subtract", position, |a, b| a - b),
+        BinaryOperator::Multiply => arithmetic(left, right, "multiply", position, |a, b| a * b),
         BinaryOperator::Divide => match (left, right) {
-            (Value::Number(_), Value::Number(0.0)) => Err(runtime_error("division by zero")),
+            (Value::Number(_), Value::Number(0.0)) => {
+                Err(runtime_error("division by zero", position))
+            }
             (Value::Number(a), Value::Number(b)) => Ok(Value::Number(a / b)),
-            (left, right) => Err(runtime_error(format!(
-                "cannot divide a {} by a {}",
-                type_name(&left),
-                type_name(&right),
-            ))),
+            (left, right) => Err(runtime_error(
+                format!(
+                    "cannot divide a {} by a {}",
+                    type_name(&left),
+                    type_name(&right),
+                ),
+                position,
+            )),
         },
-        BinaryOperator::Less => comparison(left, right, |a, b| a < b),
-        BinaryOperator::LessEqual => comparison(left, right, |a, b| a <= b),
-        BinaryOperator::Greater => comparison(left, right, |a, b| a > b),
-        BinaryOperator::GreaterEqual => comparison(left, right, |a, b| a >= b),
+        BinaryOperator::Less => comparison(left, right, position, |a, b| a < b),
+        BinaryOperator::LessEqual => comparison(left, right, position, |a, b| a <= b),
+        BinaryOperator::Greater => comparison(left, right, position, |a, b| a > b),
+        BinaryOperator::GreaterEqual => comparison(left, right, position, |a, b| a >= b),
         BinaryOperator::Equal => Ok(Value::Boolean(left == right)),
         BinaryOperator::NotEqual => Ok(Value::Boolean(left != right)),
     }
@@ -133,16 +149,20 @@ fn arithmetic(
     left: Value,
     right: Value,
     verb: &str,
+    position: SourcePosition,
     operation: fn(f64, f64) -> f64,
 ) -> Result<Value, Diagnostic> {
     match (left, right) {
         (Value::Number(a), Value::Number(b)) => Ok(Value::Number(operation(a, b))),
-        (left, right) => Err(runtime_error(format!(
-            "cannot {} a {} and a {}",
-            verb,
-            type_name(&left),
-            type_name(&right),
-        ))),
+        (left, right) => Err(runtime_error(
+            format!(
+                "cannot {} a {} and a {}",
+                verb,
+                type_name(&left),
+                type_name(&right),
+            ),
+            position,
+        )),
     }
 }
 
@@ -150,20 +170,24 @@ fn arithmetic(
 fn comparison(
     left: Value,
     right: Value,
+    position: SourcePosition,
     operation: fn(f64, f64) -> bool,
 ) -> Result<Value, Diagnostic> {
     match (left, right) {
         (Value::Number(a), Value::Number(b)) => Ok(Value::Boolean(operation(a, b))),
-        (left, right) => Err(runtime_error(format!(
-            "cannot compare a {} and a {}",
-            type_name(&left),
-            type_name(&right),
-        ))),
+        (left, right) => Err(runtime_error(
+            format!(
+                "cannot compare a {} and a {}",
+                type_name(&left),
+                type_name(&right),
+            ),
+            position,
+        )),
     }
 }
 
-fn runtime_error(message: impl Into<String>) -> Diagnostic {
-    Diagnostic::new(message, SourcePosition { character_index: 0 })
+fn runtime_error(message: impl Into<String>, position: SourcePosition) -> Diagnostic {
+    Diagnostic::new(message, position)
 }
 
 /// The truthiness convention: `nil` and `false` are falsy; everything else,

--- a/crates/amarok-interpreter/tests/binary.rs
+++ b/crates/amarok-interpreter/tests/binary.rs
@@ -1,18 +1,18 @@
 use amarok_interpreter::Value;
-use amarok_syntax::{BinaryOperator, Expression};
+use amarok_syntax::{BinaryOperator, Expression, ExpressionKind};
 mod common;
-use common::eval;
+use common::{eval, expression};
 
 fn number(value: f64) -> Expression {
-    Expression::NumberLiteral(value)
+    expression(ExpressionKind::NumberLiteral(value))
 }
 
 fn binary(left: Expression, operator: BinaryOperator, right: Expression) -> Expression {
-    Expression::Binary {
+    expression(ExpressionKind::Binary {
         left: Box::new(left),
         operator,
         right: Box::new(right),
-    }
+    })
 }
 
 #[test]
@@ -26,9 +26,9 @@ fn addition_of_numbers() {
 #[test]
 fn string_concatenation() {
     let expression = binary(
-        Expression::StringLiteral(String::from("foo")),
+        expression(ExpressionKind::StringLiteral(String::from("foo"))),
         BinaryOperator::Add,
-        Expression::StringLiteral(String::from("bar")),
+        expression(ExpressionKind::StringLiteral(String::from("bar"))),
     );
     assert_eq!(eval(&expression), Ok(Value::String(String::from("foobar"))));
 }
@@ -38,7 +38,7 @@ fn adding_a_number_and_a_string_is_a_runtime_error() {
     let expression = binary(
         number(1.0),
         BinaryOperator::Add,
-        Expression::StringLiteral(String::from("x")),
+        expression(ExpressionKind::StringLiteral(String::from("x"))),
     );
     assert!(eval(&expression).is_err());
 }
@@ -73,7 +73,7 @@ fn equality_across_different_types_is_false_not_an_error() {
     let expression = binary(
         number(1.0),
         BinaryOperator::Equal,
-        Expression::StringLiteral(String::from("1")),
+        expression(ExpressionKind::StringLiteral(String::from("1"))),
     );
     assert_eq!(eval(&expression), Ok(Value::Boolean(false)));
 }

--- a/crates/amarok-interpreter/tests/common/mod.rs
+++ b/crates/amarok-interpreter/tests/common/mod.rs
@@ -1,8 +1,19 @@
-use amarok_diagnostics::Diagnostic;
+// Helpers are shared across the interpreter test files; not every file uses
+// every helper, so allow dead code rather than warn per test binary.
+#![allow(dead_code)]
+
+use amarok_diagnostics::{Diagnostic, SourcePosition};
 use amarok_interpreter::{Environment, Value, evaluate};
-use amarok_syntax::Expression;
+use amarok_syntax::{Expression, ExpressionKind};
 
 /// Evaluate with no variables in scope — for the many tests that don't use any.
 pub fn eval(expression: &Expression) -> Result<Value, Diagnostic> {
     evaluate(expression, &Environment::new())
+}
+
+/// Build an expression node at the zero position. Evaluation only reads the
+/// position on error paths (to point a caret), and these tests don't assert on
+/// it, so a zero position is fine everywhere.
+pub fn expression(kind: ExpressionKind) -> Expression {
+    kind.at(SourcePosition { character_index: 0 })
 }

--- a/crates/amarok-interpreter/tests/literals_and_unary.rs
+++ b/crates/amarok-interpreter/tests/literals_and_unary.rs
@@ -1,79 +1,81 @@
 use amarok_interpreter::Value;
-use amarok_syntax::{Expression, UnaryOperator};
+use amarok_syntax::{ExpressionKind, UnaryOperator};
 mod common;
-use common::eval;
+use common::{eval, expression};
 
 #[test]
 fn a_number_literal_evaluates_to_a_number() {
     assert_eq!(
-        eval(&Expression::NumberLiteral(42.0)),
+        eval(&expression(ExpressionKind::NumberLiteral(42.0))),
         Ok(Value::Number(42.0))
     );
 }
 
 #[test]
 fn a_string_literal_evaluates_to_a_string() {
-    let expression = Expression::StringLiteral(String::from("hello"));
+    let expression = expression(ExpressionKind::StringLiteral(String::from("hello")));
     assert_eq!(eval(&expression), Ok(Value::String(String::from("hello"))));
 }
 
 #[test]
 fn negation_negates_a_number() {
     // -5
-    let expression = Expression::Unary {
+    let expression = expression(ExpressionKind::Unary {
         operator: UnaryOperator::Negate,
-        operand: Box::new(Expression::NumberLiteral(5.0)),
-    };
+        operand: Box::new(expression(ExpressionKind::NumberLiteral(5.0))),
+    });
     assert_eq!(eval(&expression), Ok(Value::Number(-5.0)));
 }
 
 #[test]
 fn not_of_true_is_false() {
-    let expression = Expression::Unary {
+    let expression = expression(ExpressionKind::Unary {
         operator: UnaryOperator::Not,
-        operand: Box::new(Expression::BooleanLiteral(true)),
-    };
+        operand: Box::new(expression(ExpressionKind::BooleanLiteral(true))),
+    });
     assert_eq!(eval(&expression), Ok(Value::Boolean(false)));
 }
 
 #[test]
 fn not_of_nil_is_true_because_nil_is_falsy() {
-    let expression = Expression::Unary {
+    let expression = expression(ExpressionKind::Unary {
         operator: UnaryOperator::Not,
-        operand: Box::new(Expression::NilLiteral),
-    };
+        operand: Box::new(expression(ExpressionKind::NilLiteral)),
+    });
     assert_eq!(eval(&expression), Ok(Value::Boolean(true)));
 }
 
 #[test]
 fn not_of_a_number_is_false_because_numbers_are_truthy() {
     // not 5  →  false
-    let expression = Expression::Unary {
+    let expression = expression(ExpressionKind::Unary {
         operator: UnaryOperator::Not,
-        operand: Box::new(Expression::NumberLiteral(5.0)),
-    };
+        operand: Box::new(expression(ExpressionKind::NumberLiteral(5.0))),
+    });
     assert_eq!(eval(&expression), Ok(Value::Boolean(false)));
 }
 
 #[test]
 fn negating_a_string_is_a_runtime_error() {
     // -"hello"
-    let expression = Expression::Unary {
+    let expression = expression(ExpressionKind::Unary {
         operator: UnaryOperator::Negate,
-        operand: Box::new(Expression::StringLiteral(String::from("hello"))),
-    };
+        operand: Box::new(expression(ExpressionKind::StringLiteral(String::from(
+            "hello",
+        )))),
+    });
     assert!(eval(&expression).is_err());
 }
 
 #[test]
 fn double_negation_evaluates_through_both_layers() {
     // - - 5  →  5
-    let expression = Expression::Unary {
+    let expression = expression(ExpressionKind::Unary {
         operator: UnaryOperator::Negate,
-        operand: Box::new(Expression::Unary {
+        operand: Box::new(expression(ExpressionKind::Unary {
             operator: UnaryOperator::Negate,
-            operand: Box::new(Expression::NumberLiteral(5.0)),
-        }),
-    };
+            operand: Box::new(expression(ExpressionKind::NumberLiteral(5.0))),
+        })),
+    });
     assert_eq!(eval(&expression), Ok(Value::Number(5.0)));
 }

--- a/crates/amarok-interpreter/tests/statements.rs
+++ b/crates/amarok-interpreter/tests/statements.rs
@@ -1,12 +1,15 @@
 use amarok_interpreter::{Environment, Value, execute_statement};
-use amarok_syntax::{BinaryOperator, Expression, Statement};
+use amarok_syntax::{BinaryOperator, ExpressionKind, Statement};
+
+mod common;
+use common::expression;
 
 #[test]
 fn a_let_binds_a_variable_and_yields_no_value() {
     let mut environment = Environment::new();
     let statement = Statement::Let {
         name: String::from("x"),
-        initializer: Expression::NumberLiteral(5.0),
+        initializer: expression(ExpressionKind::NumberLiteral(5.0)),
     };
     assert_eq!(execute_statement(&statement, &mut environment), Ok(None));
     assert_eq!(environment.get("x"), Some(&Value::Number(5.0)));
@@ -15,7 +18,7 @@ fn a_let_binds_a_variable_and_yields_no_value() {
 #[test]
 fn an_expression_statement_yields_its_value() {
     let mut environment = Environment::new();
-    let statement = Statement::Expression(Expression::NumberLiteral(42.0));
+    let statement = Statement::Expression(expression(ExpressionKind::NumberLiteral(42.0)));
     assert_eq!(
         execute_statement(&statement, &mut environment),
         Ok(Some(Value::Number(42.0))),
@@ -28,18 +31,18 @@ fn a_later_statement_sees_an_earlier_binding() {
     execute_statement(
         &Statement::Let {
             name: String::from("x"),
-            initializer: Expression::NumberLiteral(5.0),
+            initializer: expression(ExpressionKind::NumberLiteral(5.0)),
         },
         &mut environment,
     )
     .unwrap();
     // x + 1
     let result = execute_statement(
-        &Statement::Expression(Expression::Binary {
-            left: Box::new(Expression::Variable(String::from("x"))),
+        &Statement::Expression(expression(ExpressionKind::Binary {
+            left: Box::new(expression(ExpressionKind::Variable(String::from("x")))),
             operator: BinaryOperator::Add,
-            right: Box::new(Expression::NumberLiteral(1.0)),
-        }),
+            right: Box::new(expression(ExpressionKind::NumberLiteral(1.0))),
+        })),
         &mut environment,
     );
     assert_eq!(result, Ok(Some(Value::Number(6.0))));

--- a/crates/amarok-interpreter/tests/variables.rs
+++ b/crates/amarok-interpreter/tests/variables.rs
@@ -1,18 +1,21 @@
 use amarok_interpreter::{Environment, Value, evaluate};
-use amarok_syntax::{BinaryOperator, Expression};
+use amarok_syntax::{BinaryOperator, ExpressionKind};
+
+mod common;
+use common::expression;
 
 #[test]
 fn a_variable_reads_its_value_from_the_environment() {
     let mut environment = Environment::new();
     environment.define("x", Value::Number(5.0));
-    let expression = Expression::Variable(String::from("x"));
+    let expression = expression(ExpressionKind::Variable(String::from("x")));
     assert_eq!(evaluate(&expression, &environment), Ok(Value::Number(5.0)));
 }
 
 #[test]
 fn an_undefined_variable_is_a_runtime_error() {
     let environment = Environment::new();
-    let expression = Expression::Variable(String::from("missing"));
+    let expression = expression(ExpressionKind::Variable(String::from("missing")));
     assert!(evaluate(&expression, &environment).is_err());
 }
 
@@ -21,10 +24,10 @@ fn a_variable_can_be_used_inside_an_expression() {
     let mut environment = Environment::new();
     environment.define("x", Value::Number(10.0));
     // x + 1
-    let expression = Expression::Binary {
-        left: Box::new(Expression::Variable(String::from("x"))),
+    let expression = expression(ExpressionKind::Binary {
+        left: Box::new(expression(ExpressionKind::Variable(String::from("x")))),
         operator: BinaryOperator::Add,
-        right: Box::new(Expression::NumberLiteral(1.0)),
-    };
+        right: Box::new(expression(ExpressionKind::NumberLiteral(1.0))),
+    });
     assert_eq!(evaluate(&expression, &environment), Ok(Value::Number(11.0)));
 }

--- a/crates/amarok-parser/src/lib.rs
+++ b/crates/amarok-parser/src/lib.rs
@@ -1,7 +1,7 @@
 pub use amarok_diagnostics::{Diagnostic, SourcePosition};
 
 use amarok_lexer::{Token, TokenKind};
-use amarok_syntax::{BinaryOperator, Expression, Statement, UnaryOperator};
+use amarok_syntax::{BinaryOperator, Expression, ExpressionKind, Statement, UnaryOperator};
 
 struct Parser {
     tokens: Vec<Token>,
@@ -45,13 +45,17 @@ impl Parser {
     ) -> Result<Expression, Diagnostic> {
         let mut left = parse_operand(self)?;
         while let Some(operator) = match_operator(self.peek()) {
+            // Capture the operator's position before consuming it; a runtime
+            // type error on this operation should point a caret here.
+            let operator_position = self.peek().position;
             self.advance();
             let right = parse_operand(self)?;
-            left = Expression::Binary {
+            left = ExpressionKind::Binary {
                 left: Box::new(left),
                 operator,
                 right: Box::new(right),
-            };
+            }
+            .at(operator_position);
         }
         Ok(left)
     }
@@ -114,33 +118,43 @@ impl Parser {
         };
         match operator {
             Some(operator) => {
+                let operator_position = self.peek().position; // the `-` or `not`
                 self.advance(); // consume the operator token
                 let operand = self.parse_unary()?; // recurse for the operand
-                Ok(Expression::Unary {
+                Ok(ExpressionKind::Unary {
                     operator,
                     operand: Box::new(operand),
-                })
+                }
+                .at(operator_position))
             }
             None => self.parse_primary(),
         }
     }
 
     fn parse_primary(&mut self) -> Result<Expression, Diagnostic> {
-        match self.advance().kind {
-            TokenKind::NumberLiteral(value) => Ok(Expression::NumberLiteral(value)),
-            TokenKind::StringLiteral(value) => Ok(Expression::StringLiteral(value)),
-            TokenKind::True => Ok(Expression::BooleanLiteral(true)),
-            TokenKind::False => Ok(Expression::BooleanLiteral(false)),
-            TokenKind::Nil => Ok(Expression::NilLiteral),
+        let token = self.advance();
+        let position = token.position;
+        match token.kind {
+            TokenKind::NumberLiteral(value) => {
+                Ok(ExpressionKind::NumberLiteral(value).at(position))
+            }
+            TokenKind::StringLiteral(value) => {
+                Ok(ExpressionKind::StringLiteral(value).at(position))
+            }
+            TokenKind::True => Ok(ExpressionKind::BooleanLiteral(true).at(position)),
+            TokenKind::False => Ok(ExpressionKind::BooleanLiteral(false).at(position)),
+            TokenKind::Nil => Ok(ExpressionKind::NilLiteral.at(position)),
             TokenKind::LeftParenthesis => {
                 let inner = self.parse_expression()?; // recurse to the TOP of the grammar
                 self.consume(
                     &TokenKind::RightParenthesis,
                     "expected ')' after expression",
                 )?;
+                // Grouping adds no node of its own; the inner expression keeps
+                // its own position.
                 Ok(inner)
             }
-            TokenKind::Identifier(name) => Ok(Expression::Variable(name)),
+            TokenKind::Identifier(name) => Ok(ExpressionKind::Variable(name).at(position)),
             unexpected => Err(Diagnostic::new(
                 format!("expected an expression, found {unexpected:?}"),
                 SourcePosition { character_index: 0 },

--- a/crates/amarok-parser/tests/binary_factor.rs
+++ b/crates/amarok-parser/tests/binary_factor.rs
@@ -2,8 +2,8 @@ mod common;
 
 use amarok_lexer::TokenKind;
 use amarok_parser::parse;
-use amarok_syntax::{BinaryOperator, Expression};
-use common::token;
+use amarok_syntax::{BinaryOperator, ExpressionKind};
+use common::{expression, token};
 
 #[test]
 fn multiplication_of_two_numbers() {
@@ -16,11 +16,11 @@ fn multiplication_of_two_numbers() {
     ];
     assert_eq!(
         parse(tokens),
-        Ok(Expression::Binary {
-            left: Box::new(Expression::NumberLiteral(2.0)),
+        Ok(expression(ExpressionKind::Binary {
+            left: Box::new(expression(ExpressionKind::NumberLiteral(2.0))),
             operator: BinaryOperator::Multiply,
-            right: Box::new(Expression::NumberLiteral(3.0)),
-        }),
+            right: Box::new(expression(ExpressionKind::NumberLiteral(3.0))),
+        })),
     );
 }
 
@@ -37,15 +37,15 @@ fn multiplication_binds_tighter_than_addition() {
     ];
     assert_eq!(
         parse(tokens),
-        Ok(Expression::Binary {
-            left: Box::new(Expression::NumberLiteral(1.0)),
+        Ok(expression(ExpressionKind::Binary {
+            left: Box::new(expression(ExpressionKind::NumberLiteral(1.0))),
             operator: BinaryOperator::Add,
-            right: Box::new(Expression::Binary {
-                left: Box::new(Expression::NumberLiteral(2.0)),
+            right: Box::new(expression(ExpressionKind::Binary {
+                left: Box::new(expression(ExpressionKind::NumberLiteral(2.0))),
                 operator: BinaryOperator::Multiply,
-                right: Box::new(Expression::NumberLiteral(3.0)),
-            }),
-        }),
+                right: Box::new(expression(ExpressionKind::NumberLiteral(3.0))),
+            })),
+        })),
     );
 }
 
@@ -62,15 +62,15 @@ fn multiplication_on_the_left_also_binds_tighter() {
     ];
     assert_eq!(
         parse(tokens),
-        Ok(Expression::Binary {
-            left: Box::new(Expression::Binary {
-                left: Box::new(Expression::NumberLiteral(2.0)),
+        Ok(expression(ExpressionKind::Binary {
+            left: Box::new(expression(ExpressionKind::Binary {
+                left: Box::new(expression(ExpressionKind::NumberLiteral(2.0))),
                 operator: BinaryOperator::Multiply,
-                right: Box::new(Expression::NumberLiteral(3.0)),
-            }),
+                right: Box::new(expression(ExpressionKind::NumberLiteral(3.0))),
+            })),
             operator: BinaryOperator::Add,
-            right: Box::new(Expression::NumberLiteral(1.0)),
-        }),
+            right: Box::new(expression(ExpressionKind::NumberLiteral(1.0))),
+        })),
     );
 }
 
@@ -87,14 +87,14 @@ fn division_is_left_associative() {
     ];
     assert_eq!(
         parse(tokens),
-        Ok(Expression::Binary {
-            left: Box::new(Expression::Binary {
-                left: Box::new(Expression::NumberLiteral(8.0)),
+        Ok(expression(ExpressionKind::Binary {
+            left: Box::new(expression(ExpressionKind::Binary {
+                left: Box::new(expression(ExpressionKind::NumberLiteral(8.0))),
                 operator: BinaryOperator::Divide,
-                right: Box::new(Expression::NumberLiteral(4.0)),
-            }),
+                right: Box::new(expression(ExpressionKind::NumberLiteral(4.0))),
+            })),
             operator: BinaryOperator::Divide,
-            right: Box::new(Expression::NumberLiteral(2.0)),
-        }),
+            right: Box::new(expression(ExpressionKind::NumberLiteral(2.0))),
+        })),
     );
 }

--- a/crates/amarok-parser/tests/binary_term.rs
+++ b/crates/amarok-parser/tests/binary_term.rs
@@ -2,8 +2,8 @@ mod common;
 
 use amarok_lexer::TokenKind;
 use amarok_parser::parse;
-use amarok_syntax::{BinaryOperator, Expression, UnaryOperator};
-use common::token;
+use amarok_syntax::{BinaryOperator, ExpressionKind, UnaryOperator};
+use common::{expression, token};
 
 #[test]
 fn addition_of_two_numbers() {
@@ -16,11 +16,11 @@ fn addition_of_two_numbers() {
     ];
     assert_eq!(
         parse(tokens),
-        Ok(Expression::Binary {
-            left: Box::new(Expression::NumberLiteral(1.0)),
+        Ok(expression(ExpressionKind::Binary {
+            left: Box::new(expression(ExpressionKind::NumberLiteral(1.0))),
             operator: BinaryOperator::Add,
-            right: Box::new(Expression::NumberLiteral(2.0)),
-        }),
+            right: Box::new(expression(ExpressionKind::NumberLiteral(2.0))),
+        })),
     );
 }
 
@@ -37,15 +37,15 @@ fn subtraction_is_left_associative() {
     ];
     assert_eq!(
         parse(tokens),
-        Ok(Expression::Binary {
-            left: Box::new(Expression::Binary {
-                left: Box::new(Expression::NumberLiteral(1.0)),
+        Ok(expression(ExpressionKind::Binary {
+            left: Box::new(expression(ExpressionKind::Binary {
+                left: Box::new(expression(ExpressionKind::NumberLiteral(1.0))),
                 operator: BinaryOperator::Subtract,
-                right: Box::new(Expression::NumberLiteral(2.0)),
-            }),
+                right: Box::new(expression(ExpressionKind::NumberLiteral(2.0))),
+            })),
             operator: BinaryOperator::Subtract,
-            right: Box::new(Expression::NumberLiteral(3.0)),
-        }),
+            right: Box::new(expression(ExpressionKind::NumberLiteral(3.0))),
+        })),
     );
 }
 
@@ -61,14 +61,14 @@ fn binary_minus_and_unary_minus_coexist() {
     ];
     assert_eq!(
         parse(tokens),
-        Ok(Expression::Binary {
-            left: Box::new(Expression::NumberLiteral(1.0)),
+        Ok(expression(ExpressionKind::Binary {
+            left: Box::new(expression(ExpressionKind::NumberLiteral(1.0))),
             operator: BinaryOperator::Subtract,
-            right: Box::new(Expression::Unary {
+            right: Box::new(expression(ExpressionKind::Unary {
                 operator: UnaryOperator::Negate,
-                operand: Box::new(Expression::NumberLiteral(2.0)),
-            }),
-        }),
+                operand: Box::new(expression(ExpressionKind::NumberLiteral(2.0))),
+            })),
+        })),
     );
 }
 
@@ -82,9 +82,9 @@ fn a_lone_unary_still_parses_through_the_term_rule() {
     ];
     assert_eq!(
         parse(tokens),
-        Ok(Expression::Unary {
+        Ok(expression(ExpressionKind::Unary {
             operator: UnaryOperator::Negate,
-            operand: Box::new(Expression::NumberLiteral(5.0)),
-        }),
+            operand: Box::new(expression(ExpressionKind::NumberLiteral(5.0))),
+        })),
     );
 }

--- a/crates/amarok-parser/tests/common/mod.rs
+++ b/crates/amarok-parser/tests/common/mod.rs
@@ -1,4 +1,9 @@
+// Helpers are shared across the parser test files; not every file uses every
+// helper, so allow dead code rather than warn per test binary.
+#![allow(dead_code)]
+
 use amarok_lexer::{SourcePosition, Token, TokenKind};
+use amarok_syntax::{Expression, ExpressionKind};
 
 /// Parser tests don't care about positions, only about kinds and the tree.
 pub fn token(kind: TokenKind) -> Token {
@@ -6,4 +11,11 @@ pub fn token(kind: TokenKind) -> Token {
         kind,
         position: SourcePosition { character_index: 0 },
     }
+}
+
+/// Build an expression node at the zero position. The `token` helper emits every
+/// token at index 0, so every parsed node lands at index 0 too — expected trees
+/// match by building with this same position.
+pub fn expression(kind: ExpressionKind) -> Expression {
+    kind.at(SourcePosition { character_index: 0 })
 }

--- a/crates/amarok-parser/tests/comparison_and_equality.rs
+++ b/crates/amarok-parser/tests/comparison_and_equality.rs
@@ -2,8 +2,8 @@ mod common;
 
 use amarok_lexer::TokenKind;
 use amarok_parser::parse;
-use amarok_syntax::{BinaryOperator, Expression};
-use common::token;
+use amarok_syntax::{BinaryOperator, ExpressionKind};
+use common::{expression, token};
 
 #[test]
 fn equality_of_two_numbers() {
@@ -16,11 +16,11 @@ fn equality_of_two_numbers() {
     ];
     assert_eq!(
         parse(tokens),
-        Ok(Expression::Binary {
-            left: Box::new(Expression::NumberLiteral(1.0)),
+        Ok(expression(ExpressionKind::Binary {
+            left: Box::new(expression(ExpressionKind::NumberLiteral(1.0))),
             operator: BinaryOperator::Equal,
-            right: Box::new(Expression::NumberLiteral(2.0)),
-        }),
+            right: Box::new(expression(ExpressionKind::NumberLiteral(2.0))),
+        })),
     );
 }
 
@@ -37,15 +37,15 @@ fn comparison_binds_tighter_than_equality() {
     ];
     assert_eq!(
         parse(tokens),
-        Ok(Expression::Binary {
-            left: Box::new(Expression::NumberLiteral(1.0)),
+        Ok(expression(ExpressionKind::Binary {
+            left: Box::new(expression(ExpressionKind::NumberLiteral(1.0))),
             operator: BinaryOperator::Equal,
-            right: Box::new(Expression::Binary {
-                left: Box::new(Expression::NumberLiteral(2.0)),
+            right: Box::new(expression(ExpressionKind::Binary {
+                left: Box::new(expression(ExpressionKind::NumberLiteral(2.0))),
                 operator: BinaryOperator::Less,
-                right: Box::new(Expression::NumberLiteral(3.0)),
-            }),
-        }),
+                right: Box::new(expression(ExpressionKind::NumberLiteral(3.0))),
+            })),
+        })),
     );
 }
 
@@ -64,18 +64,18 @@ fn the_whole_ladder_in_one_expression() {
     ];
     assert_eq!(
         parse(tokens),
-        Ok(Expression::Binary {
-            left: Box::new(Expression::NumberLiteral(1.0)),
+        Ok(expression(ExpressionKind::Binary {
+            left: Box::new(expression(ExpressionKind::NumberLiteral(1.0))),
             operator: BinaryOperator::Equal,
-            right: Box::new(Expression::Binary {
-                left: Box::new(Expression::NumberLiteral(2.0)),
+            right: Box::new(expression(ExpressionKind::Binary {
+                left: Box::new(expression(ExpressionKind::NumberLiteral(2.0))),
                 operator: BinaryOperator::Add,
-                right: Box::new(Expression::Binary {
-                    left: Box::new(Expression::NumberLiteral(3.0)),
+                right: Box::new(expression(ExpressionKind::Binary {
+                    left: Box::new(expression(ExpressionKind::NumberLiteral(3.0))),
                     operator: BinaryOperator::Multiply,
-                    right: Box::new(Expression::NumberLiteral(4.0)),
-                }),
-            }),
-        }),
+                    right: Box::new(expression(ExpressionKind::NumberLiteral(4.0))),
+                })),
+            })),
+        })),
     );
 }

--- a/crates/amarok-parser/tests/grouping.rs
+++ b/crates/amarok-parser/tests/grouping.rs
@@ -2,8 +2,8 @@ mod common;
 
 use amarok_lexer::TokenKind;
 use amarok_parser::parse;
-use amarok_syntax::{BinaryOperator, Expression};
-use common::token;
+use amarok_syntax::{BinaryOperator, ExpressionKind};
+use common::{expression, token};
 
 #[test]
 fn parentheses_around_a_literal_yield_the_literal() {
@@ -14,7 +14,10 @@ fn parentheses_around_a_literal_yield_the_literal() {
         token(TokenKind::RightParenthesis),
         token(TokenKind::EndOfFile),
     ];
-    assert_eq!(parse(tokens), Ok(Expression::NumberLiteral(42.0)));
+    assert_eq!(
+        parse(tokens),
+        Ok(expression(ExpressionKind::NumberLiteral(42.0))),
+    );
 }
 
 #[test]
@@ -32,15 +35,15 @@ fn parentheses_override_precedence() {
     ];
     assert_eq!(
         parse(tokens),
-        Ok(Expression::Binary {
-            left: Box::new(Expression::Binary {
-                left: Box::new(Expression::NumberLiteral(1.0)),
+        Ok(expression(ExpressionKind::Binary {
+            left: Box::new(expression(ExpressionKind::Binary {
+                left: Box::new(expression(ExpressionKind::NumberLiteral(1.0))),
                 operator: BinaryOperator::Add,
-                right: Box::new(Expression::NumberLiteral(2.0)),
-            }),
+                right: Box::new(expression(ExpressionKind::NumberLiteral(2.0))),
+            })),
             operator: BinaryOperator::Multiply,
-            right: Box::new(Expression::NumberLiteral(3.0)),
-        }),
+            right: Box::new(expression(ExpressionKind::NumberLiteral(3.0))),
+        })),
     );
 }
 
@@ -55,7 +58,10 @@ fn nested_parentheses_collapse_to_the_inner_expression() {
         token(TokenKind::RightParenthesis),
         token(TokenKind::EndOfFile),
     ];
-    assert_eq!(parse(tokens), Ok(Expression::NumberLiteral(42.0)));
+    assert_eq!(
+        parse(tokens),
+        Ok(expression(ExpressionKind::NumberLiteral(42.0))),
+    );
 }
 
 #[test]
@@ -70,5 +76,5 @@ fn a_missing_closing_parenthesis_is_an_error() {
     ];
     let result = parse(tokens);
     assert!(result.is_err());
-    assert!(result.unwrap_err().message.contains(")"));
+    assert!(result.unwrap_err().message.contains(')'));
 }

--- a/crates/amarok-parser/tests/literals.rs
+++ b/crates/amarok-parser/tests/literals.rs
@@ -2,8 +2,8 @@ mod common;
 
 use amarok_lexer::TokenKind;
 use amarok_parser::parse;
-use amarok_syntax::Expression;
-use common::token;
+use amarok_syntax::ExpressionKind;
+use common::{expression, token};
 
 #[test]
 fn parses_a_number_literal() {
@@ -11,7 +11,10 @@ fn parses_a_number_literal() {
         token(TokenKind::NumberLiteral(42.0)),
         token(TokenKind::EndOfFile),
     ];
-    assert_eq!(parse(tokens), Ok(Expression::NumberLiteral(42.0)));
+    assert_eq!(
+        parse(tokens),
+        Ok(expression(ExpressionKind::NumberLiteral(42.0))),
+    );
 }
 
 #[test]
@@ -22,26 +25,34 @@ fn parses_a_string_literal() {
     ];
     assert_eq!(
         parse(tokens),
-        Ok(Expression::StringLiteral(String::from("hello"))),
+        Ok(expression(ExpressionKind::StringLiteral(String::from(
+            "hello"
+        )))),
     );
 }
 
 #[test]
 fn parses_the_true_literal() {
     let tokens = vec![token(TokenKind::True), token(TokenKind::EndOfFile)];
-    assert_eq!(parse(tokens), Ok(Expression::BooleanLiteral(true)));
+    assert_eq!(
+        parse(tokens),
+        Ok(expression(ExpressionKind::BooleanLiteral(true))),
+    );
 }
 
 #[test]
 fn parses_the_false_literal() {
     let tokens = vec![token(TokenKind::False), token(TokenKind::EndOfFile)];
-    assert_eq!(parse(tokens), Ok(Expression::BooleanLiteral(false)));
+    assert_eq!(
+        parse(tokens),
+        Ok(expression(ExpressionKind::BooleanLiteral(false))),
+    );
 }
 
 #[test]
 fn parses_the_nil_literal() {
     let tokens = vec![token(TokenKind::Nil), token(TokenKind::EndOfFile)];
-    assert_eq!(parse(tokens), Ok(Expression::NilLiteral));
+    assert_eq!(parse(tokens), Ok(expression(ExpressionKind::NilLiteral)));
 }
 
 #[test]

--- a/crates/amarok-parser/tests/statements.rs
+++ b/crates/amarok-parser/tests/statements.rs
@@ -1,9 +1,9 @@
 use amarok_lexer::TokenKind;
 use amarok_parser::parse_program;
-use amarok_syntax::{BinaryOperator, Expression, Statement};
+use amarok_syntax::{BinaryOperator, ExpressionKind, Statement};
 
 mod common;
-use common::token;
+use common::{expression, token};
 
 #[test]
 fn a_let_declaration() {
@@ -20,7 +20,7 @@ fn a_let_declaration() {
         parse_program(tokens),
         Ok(vec![Statement::Let {
             name: String::from("x"),
-            initializer: Expression::NumberLiteral(5.0),
+            initializer: expression(ExpressionKind::NumberLiteral(5.0)),
         }]),
     );
 }
@@ -37,11 +37,13 @@ fn an_expression_statement() {
     ];
     assert_eq!(
         parse_program(tokens),
-        Ok(vec![Statement::Expression(Expression::Binary {
-            left: Box::new(Expression::NumberLiteral(1.0)),
-            operator: BinaryOperator::Add,
-            right: Box::new(Expression::NumberLiteral(2.0)),
-        })]),
+        Ok(vec![Statement::Expression(expression(
+            ExpressionKind::Binary {
+                left: Box::new(expression(ExpressionKind::NumberLiteral(1.0))),
+                operator: BinaryOperator::Add,
+                right: Box::new(expression(ExpressionKind::NumberLiteral(2.0))),
+            }
+        ))]),
     );
 }
 
@@ -63,9 +65,9 @@ fn several_statements_in_sequence() {
         Ok(vec![
             Statement::Let {
                 name: String::from("x"),
-                initializer: Expression::NumberLiteral(5.0),
+                initializer: expression(ExpressionKind::NumberLiteral(5.0)),
             },
-            Statement::Expression(Expression::Variable(String::from("x"))),
+            Statement::Expression(expression(ExpressionKind::Variable(String::from("x")))),
         ]),
     );
 }

--- a/crates/amarok-parser/tests/unary.rs
+++ b/crates/amarok-parser/tests/unary.rs
@@ -2,8 +2,8 @@ mod common;
 
 use amarok_lexer::TokenKind;
 use amarok_parser::parse;
-use amarok_syntax::{Expression, UnaryOperator};
-use common::token;
+use amarok_syntax::{ExpressionKind, UnaryOperator};
+use common::{expression, token};
 
 #[test]
 fn negation_of_a_number() {
@@ -15,10 +15,10 @@ fn negation_of_a_number() {
     ];
     assert_eq!(
         parse(tokens),
-        Ok(Expression::Unary {
+        Ok(expression(ExpressionKind::Unary {
             operator: UnaryOperator::Negate,
-            operand: Box::new(Expression::NumberLiteral(5.0)),
-        }),
+            operand: Box::new(expression(ExpressionKind::NumberLiteral(5.0))),
+        })),
     );
 }
 
@@ -32,10 +32,10 @@ fn logical_not_of_a_boolean() {
     ];
     assert_eq!(
         parse(tokens),
-        Ok(Expression::Unary {
+        Ok(expression(ExpressionKind::Unary {
             operator: UnaryOperator::Not,
-            operand: Box::new(Expression::BooleanLiteral(true)),
-        }),
+            operand: Box::new(expression(ExpressionKind::BooleanLiteral(true))),
+        })),
     );
 }
 
@@ -50,13 +50,13 @@ fn doubly_nested_negation() {
     ];
     assert_eq!(
         parse(tokens),
-        Ok(Expression::Unary {
+        Ok(expression(ExpressionKind::Unary {
             operator: UnaryOperator::Negate,
-            operand: Box::new(Expression::Unary {
+            operand: Box::new(expression(ExpressionKind::Unary {
                 operator: UnaryOperator::Negate,
-                operand: Box::new(Expression::NumberLiteral(5.0)),
-            }),
-        }),
+                operand: Box::new(expression(ExpressionKind::NumberLiteral(5.0))),
+            })),
+        })),
     );
 }
 
@@ -67,5 +67,8 @@ fn a_bare_literal_still_parses_with_no_unary_operator() {
         token(TokenKind::NumberLiteral(42.0)),
         token(TokenKind::EndOfFile),
     ];
-    assert_eq!(parse(tokens), Ok(Expression::NumberLiteral(42.0)));
+    assert_eq!(
+        parse(tokens),
+        Ok(expression(ExpressionKind::NumberLiteral(42.0))),
+    );
 }

--- a/crates/amarok-parser/tests/variables.rs
+++ b/crates/amarok-parser/tests/variables.rs
@@ -2,8 +2,8 @@ mod common;
 
 use amarok_lexer::TokenKind;
 use amarok_parser::parse;
-use amarok_syntax::Expression;
-use common::token;
+use amarok_syntax::ExpressionKind;
+use common::{expression, token};
 
 #[test]
 fn an_identifier_parses_as_a_variable_reference() {
@@ -11,5 +11,8 @@ fn an_identifier_parses_as_a_variable_reference() {
         token(TokenKind::Identifier(String::from("x"))),
         token(TokenKind::EndOfFile),
     ];
-    assert_eq!(parse(tokens), Ok(Expression::Variable(String::from("x"))));
+    assert_eq!(
+        parse(tokens),
+        Ok(expression(ExpressionKind::Variable(String::from("x")))),
+    );
 }

--- a/crates/amarok-syntax/Cargo.toml
+++ b/crates/amarok-syntax/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+amarok-diagnostics = { path = "../amarok-diagnostics" }

--- a/crates/amarok-syntax/src/lib.rs
+++ b/crates/amarok-syntax/src/lib.rs
@@ -1,5 +1,18 @@
+use amarok_diagnostics::SourcePosition;
+
+/// An expression node: its shape paired with the source position used to point a
+/// caret if evaluating this node fails at runtime. The position is the node's
+/// most error-relevant token — a literal/variable points at itself; a unary or
+/// binary operation points at its operator.
 #[derive(Debug, Clone, PartialEq)]
-pub enum Expression {
+pub struct Expression {
+    pub kind: ExpressionKind,
+    pub position: SourcePosition,
+}
+
+/// The shape of an expression, independent of where it sits in the source.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ExpressionKind {
     NumberLiteral(f64),
     StringLiteral(String),
     BooleanLiteral(bool),
@@ -17,6 +30,18 @@ pub enum Expression {
     },
     /// A reference to a variable by name, such as `x`.
     Variable(String),
+}
+
+impl ExpressionKind {
+    /// Attach a source position, producing a full expression node. Lets callers
+    /// build nodes fluently, e.g. `ExpressionKind::NumberLiteral(5.0).at(position)`.
+    #[allow(clippy::must_use_candidate)]
+    pub fn at(self, position: SourcePosition) -> Expression {
+        Expression {
+            kind: self,
+            position,
+        }
+    }
 }
 
 /// An operator that takes a single operand.


### PR DESCRIPTION
## Summary
This change refactors the expression AST to track source positions, enabling runtime errors to point to the exact location in the source code where they occur. Previously, runtime errors always pointed to character index 0; now they point to the relevant token (literals/variables point to themselves, operators point to the operator token).

## Key Changes

- **Expression AST restructuring**: Split `Expression` enum into `ExpressionKind` (the shape) and `Expression` struct (shape + position). This allows each expression node to carry its source position.

- **Parser updates**: Modified the parser to capture and attach source positions when constructing expression nodes:
  - Literals and variables capture their token position
  - Unary operators capture the operator token position
  - Binary operators capture the operator token position (not the operands)

- **Interpreter error reporting**: Updated evaluation functions to accept and use `SourcePosition` parameters:
  - `evaluate_unary`, `evaluate_binary`, `arithmetic`, and `comparison` now receive position
  - `runtime_error` helper now takes a position parameter
  - All error paths now point to the most relevant token for the error

- **Test infrastructure**: Added `expression()` helper functions in test common modules to construct expression nodes at position 0, matching the zero-position tokens used in tests.

- **CLI improvements**: Enhanced error output to display carets pointing to error locations, matching the visual format of lex and parse errors.

## Notable Implementation Details

- The `ExpressionKind::at()` method provides a fluent API for attaching positions: `ExpressionKind::NumberLiteral(5.0).at(position)`
- For binary operations, the position points to the operator token, not the operands, since that's where type mismatches and invalid operations are most relevant
- All test files were updated to use the new `ExpressionKind` enum and `expression()` helper, ensuring tests continue to pass with the new structure

https://claude.ai/code/session_01VbV7ZT9wXLxCLJ7bR4wcAF