### PR TITLE
Improve parser error diagnostics with accurate source positions

### DIFF
--- a/crates/amarok-parser/src/lib.rs
+++ b/crates/amarok-parser/src/lib.rs
@@ -30,11 +30,8 @@ impl Parser {
             self.advance();
             Ok(())
         } else {
-            Err(Diagnostic::new(
-                message,
-                // Placeholder position, same as our other parser errors for now.
-                SourcePosition { character_index: 0 },
-            ))
+            // Point the caret at the unexpected token we actually found.
+            Err(Diagnostic::new(message, self.peek().position))
         }
     }
 
@@ -157,7 +154,7 @@ impl Parser {
             TokenKind::Identifier(name) => Ok(ExpressionKind::Variable(name).at(position)),
             unexpected => Err(Diagnostic::new(
                 format!("expected an expression, found {unexpected:?}"),
-                SourcePosition { character_index: 0 },
+                position,
             )),
         }
     }


### PR DESCRIPTION
## Summary
This PR improves the quality of parser error messages by reporting the actual source position of unexpected tokens instead of using placeholder positions.

## Key Changes
- **expect() method**: Changed error reporting to use `self.peek().position` instead of a hardcoded zero position, pointing the caret at the actual unexpected token encountered
- **primary() method**: Updated the "expected an expression" error to report the position of the unexpected token rather than a placeholder position

## Implementation Details
These changes ensure that parser diagnostics now accurately indicate where in the source code the error occurred, making it easier for users to identify and fix syntax errors. The error messages will now point to the exact token that caused the parsing failure rather than the beginning of the file.

https://claude.ai/code/session_011FRpcxW1poaibM8rcPg45D